### PR TITLE
Add automation workflow

### DIFF
--- a/.github/workflows/autoclass.yml
+++ b/.github/workflows/autoclass.yml
@@ -1,0 +1,20 @@
+name: AutoClassSchedule
+on:
+  schedule:
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: node index.cjs
+        env:
+          USER_ID: ${{ secrets.USER_ID }}
+          USER_PASS: ${{ secrets.USER_PASS }}
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+crash_*.png

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Auto-Class Bot
+
+This project schedules classes automatically using Playwright.
+
+## Setup
+
+Install dependencies and run locally:
+
+```bash
+npm install
+USER_ID=your_user \
+USER_PASS=your_pass \
+WEBHOOK_URL=https://discordapp.com/api/webhooks/... \
+node index.cjs
+```
+
+## GitHub Actions
+
+A workflow is included to run the script daily at 23:00 UTC. Configure the variables `USER_ID`, `USER_PASS`, and `WEBHOOK_URL` as repository secrets for the workflow to work.

--- a/index.cjs
+++ b/index.cjs
@@ -61,8 +61,8 @@ async function seleccionarFilaPendiente(pop, page) {
 
 /* ─── FLUJO PRINCIPAL ──────────────────────────────────────────── */
 (async () => {
-  const browser = await chromium.launch({ headless: true });
-  const ctx     = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+  const browser = await chromium.launch({ headless: true, args: ["--ignore-certificate-errors"] });
+  const ctx     = await browser.newContext({ viewport: { width: 1280, height: 720 }, ignoreHTTPSErrors: true });
   const page    = await ctx.newPage();
   page.setDefaultTimeout(90_000);
 


### PR DESCRIPTION
## Summary
- update launch options in `index.cjs` to ignore certificate errors
- add GitHub Actions workflow for scheduled runs
- add README with usage instructions
- add `.gitignore`

## Testing
- `npm install`
- `USER_ID=foo USER_PASS=bar WEBHOOK_URL=https://example.com node index.cjs > /tmp/run.log 2>&1` *(fails: Timeout 90000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_683f94727c508332bdcdb9ba1daa082d